### PR TITLE
Fix favicon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,6 @@
   {% endif %}
 
   <title>{{ page.title }} - {{ site.title }}</title>
-  <link rel="shortcut icon" type="image/png" href="assets/images/favicon_new.png">
   <link rel="stylesheet" href="{{ "/assets/css/just-the-docs.css" | absolute_url }}">
 
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700" rel="stylesheet">


### PR DESCRIPTION
placing icon in root of actual website instead - if we do want to use the rel="shortcut icon" link type setup we should include all types (apple-touch-icon etc). The existing use applies to the root of the website but doesn't work for sub sections. I think root favicon will fix this. The .ico file is being placed in the blockstream/docs repo, not here.